### PR TITLE
Update Tagalong version to 2026

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ gradle-app.setting
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
+gradle.properties
 
 # # VS Code Specific Java Settings
 .classpath

--- a/TagalongLib.json
+++ b/TagalongLib.json
@@ -1,8 +1,8 @@
 {
   "fileName": "TagalongLib.json",
   "name": "TagalongLib",
-  "version": "2025.21.0204",
-  "frcYear": "2025",
+  "version": "2026.1",
+  "frcYear": "2026",
   "uuid": "32b609c1-86c7-4c61-a0f7-7debd9d77017",
   "mavenUrls": ["https://maven.pkg.github.com/Team1868/TagalongLib"],
   "jsonUrl": "https://github.com/team1868/TagalongLib/releases/latest/download/TagalongLib.json",
@@ -10,7 +10,7 @@
     {
       "groupId": "com.tagalong.lib",
       "artifactId": "tagalonglib-java",
-      "version": "2025.21.0204"
+      "version": "2026.1"
     }
   ],
   "jniDependencies": [],

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
     // id 'google-test'
     id 'edu.wpi.first.wpilib.repositories.WPILibRepositoriesPlugin' version '2020.2'
     // id 'edu.wpi.first.NativeUtils' version '2025.1.1'
-    id "edu.wpi.first.GradleRIO" version "2026.1.0.0"
-    id 'edu.wpi.first.GradleJni' version '1.1.0'
+    id "edu.wpi.first.GradleRIO" version "2026.2.1"
+    id 'edu.wpi.first.GradleJni' version '1.2.0'
     id 'edu.wpi.first.GradleVsCode' version '2.1.0'
     // id 'com.diffplug.spotless' version '6.25.0'
     id 'edu.wpi.first.WpilibTools' version '1.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
     // id 'google-test'
     id 'edu.wpi.first.wpilib.repositories.WPILibRepositoriesPlugin' version '2020.2'
     // id 'edu.wpi.first.NativeUtils' version '2025.1.1'
-    id "edu.wpi.first.GradleRIO" version "2025.2.1"
+    id "edu.wpi.first.GradleRIO" version "2026.1.0.0"
     id 'edu.wpi.first.GradleJni' version '1.1.0'
     id 'edu.wpi.first.GradleVsCode' version '2.1.0'
     // id 'com.diffplug.spotless' version '6.25.0'
@@ -60,14 +60,14 @@ dependencies {
     // implementation group: 'com.ctre.phoenix', name: 'wpiapi-java', version: '5.33.0'
     implementation group: 'org.littletonrobotics.akit', name: 'akit-java', version: '4.0.0'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.11.0'
-    implementation group: 'edu.wpi.first.wpilibj', name: 'wpilibj-java', version: '2025.2.1'
-    implementation group: 'edu.wpi.first.wpiutil', name: 'wpiutil-java', version: '2025.2.1'
-    implementation group: 'edu.wpi.first.wpimath', name: 'wpimath-java', version: '2025.2.1'
-    implementation group: 'edu.wpi.first.wpilibNewCommands', name: 'wpilibNewCommands-java', version: '2025.2.1'
-    implementation group: 'edu.wpi.first.wpiunits', name: 'wpiunits-java', version: '2025.2.1'
-    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-java', version: '2025.2.1'
-    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-jni', version: '2025.2.1'
-    implementation group: 'edu.wpi.first.cscore', name: 'cscore-java', version: '2025.2.1'
+    implementation group: 'edu.wpi.first.wpilibj', name: 'wpilibj-java', version: '2026.1.0.0'
+    implementation group: 'edu.wpi.first.wpiutil', name: 'wpiutil-java', version: '2026.1.0.0'
+    implementation group: 'edu.wpi.first.wpimath', name: 'wpimath-java', version: '2026.1.0.0'
+    implementation group: 'edu.wpi.first.wpilibNewCommands', name: 'wpilibNewCommands-java', version: '2026.1.0.0'
+    implementation group: 'edu.wpi.first.wpiunits', name: 'wpiunits-java', version: '2026.1.0.0'
+    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-java', version: '2026.1.0.0'
+    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-jni', version: '2026.1.0.0'
+    implementation group: 'edu.wpi.first.cscore', name: 'cscore-java', version: '2026.1.0.0'
 
     implementation 'us.hebi.quickbuf:quickbuf-runtime:1.4'
 
@@ -77,9 +77,9 @@ dependencies {
 
 
     // This is needed to use wpilibj Filesystem class
-    testImplementation 'edu.wpi.first.cscore:cscore-java:2025.+'
-    testImplementation 'edu.wpi.first.cameraserver:cameraserver-java:2025.+'
-    testImplementation 'edu.wpi.first.hal:hal-java:2025.+'
+    testImplementation 'edu.wpi.first.cscore:cscore-java:2026.+'
+    testImplementation 'edu.wpi.first.cameraserver:cameraserver-java:2026.+'
+    testImplementation 'edu.wpi.first.hal:hal-java:2026.+'
 
     testImplementation 'us.hebi.quickbuf:quickbuf-runtime:1.3.3'
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ apply from: 'config.gradle'
 
 // Apply Java configuration
 dependencies {
-    implementation group: 'com.ctre.phoenix6', name: 'wpiapi-java', version: '26.2.1'
+    implementation group: 'com.ctre.phoenix6', name: 'wpiapi-java', version: '26.1.0'
     implementation group: 'org.littletonrobotics.akit', name: 'akit-java', version: '4.0.0'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.11.0'
     implementation group: 'edu.wpi.first.wpilibj', name: 'wpilibj-java', version: '2026.2.1'
@@ -63,9 +63,9 @@ dependencies {
     implementation group: 'edu.wpi.first.wpimath', name: 'wpimath-java', version: '2026.2.1'
     implementation group: 'edu.wpi.first.wpilibNewCommands', name: 'wpilibNewCommands-java', version: '2026.2.1'
     implementation group: 'edu.wpi.first.wpiunits', name: 'wpiunits-java', version: '2026.2.1'
-    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-java', version: '2026.2.1'
-    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-jni', version: '2026.2.1'
-    implementation group: 'edu.wpi.first.cscore', name: 'cscore-java', version: '2026.2.1'
+    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-java', version: '2026.1.1-beta-1'
+    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-jni', version: '2025.3.2'
+    implementation group: 'edu.wpi.first.cscore', name: 'cscore-java', version: '2026.1.1-beta-1'
 
     implementation 'us.hebi.quickbuf:quickbuf-runtime:1.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,19 +55,17 @@ apply from: 'config.gradle'
 
 // Apply Java configuration
 dependencies {
-    implementation group: 'com.ctre.phoenix6', name: 'wpiapi-java', version: '25.1.0'
-    // implementation group: 'com.ctre.phoenix', name: 'api-java', version: '5.33.0'
-    // implementation group: 'com.ctre.phoenix', name: 'wpiapi-java', version: '5.33.0'
+    implementation group: 'com.ctre.phoenix6', name: 'wpiapi-java', version: '26.2.1'
     implementation group: 'org.littletonrobotics.akit', name: 'akit-java', version: '4.0.0'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.11.0'
-    implementation group: 'edu.wpi.first.wpilibj', name: 'wpilibj-java', version: '2026.1.0.0'
-    implementation group: 'edu.wpi.first.wpiutil', name: 'wpiutil-java', version: '2026.1.0.0'
-    implementation group: 'edu.wpi.first.wpimath', name: 'wpimath-java', version: '2026.1.0.0'
-    implementation group: 'edu.wpi.first.wpilibNewCommands', name: 'wpilibNewCommands-java', version: '2026.1.0.0'
-    implementation group: 'edu.wpi.first.wpiunits', name: 'wpiunits-java', version: '2026.1.0.0'
-    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-java', version: '2026.1.0.0'
-    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-jni', version: '2026.1.0.0'
-    implementation group: 'edu.wpi.first.cscore', name: 'cscore-java', version: '2026.1.0.0'
+    implementation group: 'edu.wpi.first.wpilibj', name: 'wpilibj-java', version: '2026.2.1'
+    implementation group: 'edu.wpi.first.wpiutil', name: 'wpiutil-java', version: '2026.2.1'
+    implementation group: 'edu.wpi.first.wpimath', name: 'wpimath-java', version: '2026.2.1'
+    implementation group: 'edu.wpi.first.wpilibNewCommands', name: 'wpilibNewCommands-java', version: '2026.2.1'
+    implementation group: 'edu.wpi.first.wpiunits', name: 'wpiunits-java', version: '2026.2.1'
+    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-java', version: '2026.2.1'
+    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-jni', version: '2026.2.1'
+    implementation group: 'edu.wpi.first.cscore', name: 'cscore-java', version: '2026.2.1'
 
     implementation 'us.hebi.quickbuf:quickbuf-runtime:1.4'
 

--- a/config.gradle
+++ b/config.gradle
@@ -9,10 +9,10 @@ nativeUtils.withCrossLinuxArm64()
 nativeUtils {
     wpi {
         configureDependencies {
-            wpiVersion = "2025.2.1"
-            opencvYear = "frc2025"
-            googleTestYear = "frc2025"
-            niLibVersion = "2025.2.1"
+            wpiVersion = "2026.1.0.0"
+            opencvYear = "frc2026"
+            googleTestYear = "frc2026"
+            niLibVersion = "2026.1.0.0"
             opencvVersion = "4.8.0-2"
             googleTestVersion = "1.14.0-1"
         }

--- a/config.gradle
+++ b/config.gradle
@@ -9,10 +9,10 @@ nativeUtils.withCrossLinuxArm64()
 nativeUtils {
     wpi {
         configureDependencies {
-            wpiVersion = "2026.1.0.0"
+            wpiVersion = "2026.2.1"
             opencvYear = "frc2026"
             googleTestYear = "frc2026"
-            niLibVersion = "2026.1.0.0"
+            niLibVersion = "2026.2.1"
             opencvVersion = "4.8.0-2"
             googleTestVersion = "1.14.0-1"
         }

--- a/publish.gradle
+++ b/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 ext.licenseFile = files("$rootDir/LICENSE.txt")
 
-def pubVersion = '2025.0.0065'
+def pubVersion = '2026.1.00'
 
 def outputsFolder = file("$buildDir/outputs")
 


### PR DESCRIPTION
Publishing for 2026 season, updating wpilib and corresponding vendor dependencies
1. Replaced all instances of 2025 versions for wpilib with the most updated version
2. Replaced all vendor deps with 2026 versions: eg ctre and edu.wpi.first.ntcore, edu.wpi.first.cscore (see files changed for more)
3. Added gradleproperties to gitignore for protecting username and password of personal access token for publishing (see publish.gradle)