### PR TITLE
2026 cleanup PR

### DIFF
--- a/LICENSE-Tagalong.md
+++ b/LICENSE-Tagalong.md
@@ -1,4 +1,4 @@
-Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ Due to the required pairing of specific WPILib versions and other dependency ver
 
 > `(WPILibVersion in format YYYY.MajorMinor).MMDD`
 
-For example, a TagalongLib release on January 1st, 2026 using WPILib version 2024.1.0 would be version `2026.10.0101`.
+For example, a TagalongLib release on January 1st, 2026 using WPILib version 2026.1.0 would be version `2026.10.0101`.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ FUTURE DEV: List out microsystems and their specialized variants
 -->
 
 ### What functionalities are coming soon?
-- 2025 vendor package support
 - More included configurations for Microsystem subtypes
 - Pivot variant without a fused encoder or mechanically zeroed
 - Simulation based unit tests
@@ -79,4 +78,4 @@ Due to the required pairing of specific WPILib versions and other dependency ver
 
 > `(WPILibVersion in format YYYY.MajorMinor).MMDD`
 
-For example, a TagalongLib release on January 1st, 2025 using WPILib version 2024.1.0 would be version `2025.10.0101`.
+For example, a TagalongLib release on January 1st, 2026 using WPILib version 2024.1.0 would be version `2026.10.0101`.

--- a/TagalongLib.json
+++ b/TagalongLib.json
@@ -1,7 +1,7 @@
 {
   "fileName": "TagalongLib.json",
   "name": "TagalongLib",
-  "version": "2026.1",
+  "version": "2026.2",
   "frcYear": "2026",
   "uuid": "32b609c1-86c7-4c61-a0f7-7debd9d77017",
   "mavenUrls": ["https://maven.pkg.github.com/Team1868/TagalongLib"],
@@ -10,7 +10,7 @@
     {
       "groupId": "com.tagalong.lib",
       "artifactId": "tagalonglib-java",
-      "version": "2026.1"
+      "version": "2026.0201.0226"
     }
   ],
   "jniDependencies": [],

--- a/build.gradle
+++ b/build.gradle
@@ -63,9 +63,9 @@ dependencies {
     implementation group: 'edu.wpi.first.wpimath', name: 'wpimath-java', version: '2026.2.1'
     implementation group: 'edu.wpi.first.wpilibNewCommands', name: 'wpilibNewCommands-java', version: '2026.2.1'
     implementation group: 'edu.wpi.first.wpiunits', name: 'wpiunits-java', version: '2026.2.1'
-    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-java', version: '2026.1.1-beta-1'
+    implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-java', version: '2026.2.1'
     implementation group: 'edu.wpi.first.ntcore', name: 'ntcore-jni', version: '2025.3.2'
-    implementation group: 'edu.wpi.first.cscore', name: 'cscore-java', version: '2026.1.1-beta-1'
+    implementation group: 'edu.wpi.first.cscore', name: 'cscore-java', version: '2026.1.1'
 
     implementation 'us.hebi.quickbuf:quickbuf-runtime:1.4'
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ apply from: 'config.gradle'
 // Apply Java configuration
 dependencies {
     implementation group: 'com.ctre.phoenix6', name: 'wpiapi-java', version: '26.1.0'
-    implementation group: 'org.littletonrobotics.akit', name: 'akit-java', version: '4.0.0'
+    implementation group: 'org.littletonrobotics.akit', name: 'akit-java', version: '26.0.0'
     implementation group: 'com.google.code.gson', name: 'gson', version: '2.11.0'
     implementation group: 'edu.wpi.first.wpilibj', name: 'wpilibj-java', version: '2026.2.1'
     implementation group: 'edu.wpi.first.wpiutil', name: 'wpiutil-java', version: '2026.2.1'

--- a/publish.gradle
+++ b/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 ext.licenseFile = files("$rootDir/LICENSE.txt")
 
-def pubVersion = '2026.1.00'
+def pubVersion = '2026.2.0226'
 
 def outputsFolder = file("$buildDir/outputs")
 

--- a/publish.gradle
+++ b/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 ext.licenseFile = files("$rootDir/LICENSE.txt")
 
-def pubVersion = '2026.2.0226'
+def pubVersion = '2026.0201.0226'
 
 def outputsFolder = file("$buildDir/outputs")
 

--- a/scripts/auto-copyright.sh
+++ b/scripts/auto-copyright.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+# Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
 # Open Source Software; you may modify and/or share it under the terms of
 # the 3-Clause BSD License found in the root directory of this project.
 

--- a/scripts/update-docs.sh
+++ b/scripts/update-docs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+# Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
 # Open Source Software; you may modify and/or share it under the terms of
 # the 3-Clause BSD License found in the root directory of this project.
 

--- a/src/main/java/tagalong/TagalongConfiguration.java
+++ b/src/main/java/tagalong/TagalongConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/TagalongCommand.java
+++ b/src/main/java/tagalong/commands/TagalongCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/aim/PivotAimAtCmd.java
+++ b/src/main/java/tagalong/commands/aim/PivotAimAtCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/aim/PivotAimAtYawCompCmd.java
+++ b/src/main/java/tagalong/commands/aim/PivotAimAtYawCompCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/aim/RollerAimAtCmd.java
+++ b/src/main/java/tagalong/commands/aim/RollerAimAtCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/aim/RollerAimAtYawCompCmd.java
+++ b/src/main/java/tagalong/commands/aim/RollerAimAtYawCompCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/base/ElevateToCmd.java
+++ b/src/main/java/tagalong/commands/base/ElevateToCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/base/ElevateToDynamicCmd.java
+++ b/src/main/java/tagalong/commands/base/ElevateToDynamicCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/base/ElevateXCmd.java
+++ b/src/main/java/tagalong/commands/base/ElevateXCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/base/ElevatorZeroCmd.java
+++ b/src/main/java/tagalong/commands/base/ElevatorZeroCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/base/PivotEncoderlessZeroCmd.java
+++ b/src/main/java/tagalong/commands/base/PivotEncoderlessZeroCmd.java
@@ -77,7 +77,9 @@ public class PivotEncoderlessZeroCmd<T extends TagalongSubsystemBase & PivotAugm
    *                 Subsystem
    * @param pivot the pivot subsystem
    * @param hardstopPositionRot the angle of the pivot when against the hardstop
-   * @param power speed and direction to drive the pivot into the hardstop
+   * @param powerV speed and direction to drive the pivot into the hardstop
+   * @param stallToleranceRot angular distance traveled where the mechanism is still considered
+   *     stalled
    * @param stallDurationS time stalled before the system is considered zeroed in seconds
    */
   public PivotEncoderlessZeroCmd(

--- a/src/main/java/tagalong/commands/base/PivotEncoderlessZeroCmd.java
+++ b/src/main/java/tagalong/commands/base/PivotEncoderlessZeroCmd.java
@@ -117,7 +117,7 @@ public class PivotEncoderlessZeroCmd<T extends TagalongSubsystemBase & PivotAugm
   public void end(boolean interrupted) {
     _pivot.setPrimaryPower(0.0);
     if (!interrupted)
-      _pivot.setElevatorHeight(_endAngleRot);
+      _pivot.setPivotPosition(_endAngleRot);
   }
 
   @Override

--- a/src/main/java/tagalong/commands/base/PivotEncoderlessZeroCmd.java
+++ b/src/main/java/tagalong/commands/base/PivotEncoderlessZeroCmd.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Open Source Software; you may modify and/or share it under the terms of
+ * the 3-Clause BSD License found in the root directory of this project.
+ */
+package tagalong.commands.base;
+
+import edu.wpi.first.wpilibj.Timer;
+import tagalong.commands.TagalongCommand;
+import tagalong.subsystems.TagalongSubsystemBase;
+import tagalong.subsystems.micro.Pivot;
+import tagalong.subsystems.micro.augments.PivotAugment;
+
+/**
+ * Command that finds the elevator zero position and sets the encoder position
+ * to zero.
+ */
+public class PivotEncoderlessZeroCmd<T extends TagalongSubsystemBase & PivotAugment>
+    extends TagalongCommand {
+  /**
+   * Pivot subsystem.
+   */
+  private final Pivot _pivot;
+  /**
+   * Pivot zeroing power in volts
+   */
+  private final double _powerV;
+  /**
+   * Angular distance traveled where the mechanism is still considered stalled
+   */
+  private final double _stallToleranceRot;
+  /**
+   * Time stalled before the system is considered zeroed in seconds
+   */
+  private final double _zeroingDurationS;
+  /**
+   * The angle of the pivot when initialized, in rotations.
+   */
+  private double _prevAngleRot;
+  /**
+   * The angle of the pivot when against the hardstop
+   */
+  private double _endAngleRot;
+  /**
+   * Timer to track the stall duration to ensure a true bottom
+   */
+  private Timer stallTimer = new Timer();
+
+  /**
+   * Construct the command according to the below parameters.
+   *
+   * @param pivot the pivot subsystem
+   * @param hardstopPositionRot the angle of the pivot when against the hardstop
+   * @param powerV speed and direction to drive the pivot into the hardstop
+   * @param stallToleranceRot angular distance traveled where the mechanism is still considered
+   *     stalled
+   * @param stallDurationS time stalled before the system is considered zeroed in seconds
+   */
+  public PivotEncoderlessZeroCmd(
+      T pivot,
+      double hardstopPositionRot,
+      double powerV,
+      double stallToleranceRot,
+      double stallDurationS
+  ) {
+    _pivot = pivot.getPivot();
+    _powerV = powerV;
+    _stallToleranceRot = stallToleranceRot;
+    _zeroingDurationS = stallDurationS;
+    addRequirements(pivot);
+  }
+
+  /**
+   * Construct the command according to the below parameters.
+   *
+   * @param id       Integer ID of the elevator microsystem inside the Tagalong
+   *                 Subsystem
+   * @param pivot the pivot subsystem
+   * @param hardstopPositionRot the angle of the pivot when against the hardstop
+   * @param power speed and direction to drive the pivot into the hardstop
+   * @param stallDurationS time stalled before the system is considered zeroed in seconds
+   */
+  public PivotEncoderlessZeroCmd(
+      int id,
+      T pivot,
+      double hardstopPositionRot,
+      double powerV,
+      double stallToleranceRot,
+      double stallDurationS
+  ) {
+    _pivot = pivot.getPivot(id);
+    _powerV = powerV;
+    _stallToleranceRot = stallToleranceRot;
+    _zeroingDurationS = stallDurationS;
+    addRequirements(pivot);
+  }
+
+  @Override
+  public void initialize() {
+    _pivot.setPrimaryVolts(_powerV);
+    _prevAngleRot = _pivot.getPivotPosition();
+    stallTimer.reset();
+  }
+
+  @Override
+  public void execute() {
+    double currentAngleRot = _pivot.getPivotPosition();
+    if (Math.abs(_prevAngleRot - currentAngleRot) > _stallToleranceRot) {
+      stallTimer.reset();
+    } else {
+      stallTimer.start();
+    }
+    _prevAngleRot = currentAngleRot;
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    _pivot.setPrimaryPower(0.0);
+    if (!interrupted)
+      _pivot.setElevatorHeight(_endAngleRot);
+  }
+
+  @Override
+  public boolean isFinished() {
+    return stallTimer.hasElapsed(_zeroingDurationS);
+  }
+}

--- a/src/main/java/tagalong/commands/base/PivotToAbsoluteCmd.java
+++ b/src/main/java/tagalong/commands/base/PivotToAbsoluteCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/base/PivotToCmd.java
+++ b/src/main/java/tagalong/commands/base/PivotToCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */
@@ -374,11 +374,11 @@ public class PivotToCmd<T extends TagalongSubsystemBase & PivotAugment> extends 
    *                                     command
    * @param maxAccelerationRPS2          The maximum acceleration of the pivot, in rotations per
    *                                     second squared, during this command
-   * @param upperToleranceRot            The number of rotations beyond the target
-   *                                     position the pivot can be
-   *                                     while still being considered in tolerance
    * @param lowerToleranceRot            The number of rotations short of the
    *                                     target position the pivot can be
+   *                                     while still being considered in tolerance
+   * @param upperToleranceRot            The number of rotations beyond the target
+   *                                     position the pivot can be
    *                                     while still being considered in tolerance
    * @param requiredInToleranceDurationS The number of seconds that being in
    *                                     tolerance is required for
@@ -512,6 +512,8 @@ public class PivotToCmd<T extends TagalongSubsystemBase & PivotAugment> extends 
    * @param maxVelocityRPS               The maximum velocity of the pivot, in
    *                                     rotations per second, during this
    *                                     command
+   * @param maxAccelerationRPS2          The maximum acceleration of the pivot, in rotations per
+   *                                     second squared, during this command
    * @param lowerToleranceRot            The number of rotations short of the
    *                                     target position the pivot can be
    *                                     while still being considered in tolerance

--- a/src/main/java/tagalong/commands/base/PivotToDynamicAbsoluteCmd.java
+++ b/src/main/java/tagalong/commands/base/PivotToDynamicAbsoluteCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/base/PivotToDynamicCmd.java
+++ b/src/main/java/tagalong/commands/base/PivotToDynamicCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/base/PivotXCmd.java
+++ b/src/main/java/tagalong/commands/base/PivotXCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/base/RollToCmd.java
+++ b/src/main/java/tagalong/commands/base/RollToCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/base/RollToDynamicCmd.java
+++ b/src/main/java/tagalong/commands/base/RollToDynamicCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/commands/base/RollXCmd.java
+++ b/src/main/java/tagalong/commands/base/RollXCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/controls/FeedforwardConstants.java
+++ b/src/main/java/tagalong/controls/FeedforwardConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/controls/PIDConstants.java
+++ b/src/main/java/tagalong/controls/PIDConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/controls/PIDSGVAConstants.java
+++ b/src/main/java/tagalong/controls/PIDSGVAConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/devices/CanDeviceInterface.java
+++ b/src/main/java/tagalong/devices/CanDeviceInterface.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/devices/Encoders.java
+++ b/src/main/java/tagalong/devices/Encoders.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/devices/Motors.java
+++ b/src/main/java/tagalong/devices/Motors.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */
@@ -36,14 +36,12 @@ public enum Motors implements CanDeviceInterface {
   FALCON500_FOC(6080, DCMotor::getFalcon500),
   /**
    * Kraken X44
-   * FUTURE DEV: Waiting for motor specifications v2025
    */
-  KRAKEN_X44(1, DCMotor::getKrakenX60),
+  KRAKEN_X44(7758, DCMotor::getKrakenX44),
   /**
-   * Kraken X44 in FOC mode -- RPM WAITING FOR SPEC
-   * FUTURE DEV: Waiting for motor specifications v2025
+   * Kraken X44 in FOC mode
    */
-  KRAKEN_X44_FOC(1, DCMotor::getKrakenX60Foc);
+  KRAKEN_X44_FOC(7368, DCMotor::getKrakenX44Foc);
 
   /**
    * Max free speed RPM and converted RPS of the motor

--- a/src/main/java/tagalong/devices/TagalongCANBus.java
+++ b/src/main/java/tagalong/devices/TagalongCANBus.java
@@ -1,16 +1,17 @@
 package tagalong.devices;
 
 import com.ctre.phoenix6.CANBus;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Tagalong CANBus manager instance manager, only CTRE devices are currently registered or supported
+ * Tagalong CANBus instance manager, only CTRE devices are currently registered or supported
  */
 public class TagalongCANBus {
   /**
    * Map of all instances with a CTRE device registered to them
    */
-  private static final Map<String, CANBus> _ctreCANBus = Map.of();
+  private static final Map<String, CANBus> _ctreCANBus = new HashMap<>();
 
   /**
    * Gets or registers a CTRE CANBus instance with the given name

--- a/src/main/java/tagalong/devices/TagalongCANBus.java
+++ b/src/main/java/tagalong/devices/TagalongCANBus.java
@@ -1,8 +1,7 @@
 package tagalong.devices;
 
-import java.util.Map;
-
 import com.ctre.phoenix6.CANBus;
+import java.util.Map;
 
 /**
  * Tagalong CANBus manager instance manager, only CTRE devices are currently registered or supported
@@ -15,7 +14,7 @@ public class TagalongCANBus {
 
   /**
    * Gets or registers a CTRE CANBus instance with the given name
-   * 
+   *
    * @param canBusName Name of the CANBus
    * @return CTRE CANBus instance
    */
@@ -30,11 +29,10 @@ public class TagalongCANBus {
 
   /**
    * Gets the map of all registered CTRE CANBus instances
-   * 
+   *
    * @return Map of CANBus instances
    */
   public static Map<String, CANBus> getPhoenixCANBusMap() {
     return _ctreCANBus;
   }
-
 }

--- a/src/main/java/tagalong/devices/TagalongCANBus.java
+++ b/src/main/java/tagalong/devices/TagalongCANBus.java
@@ -1,0 +1,40 @@
+package tagalong.devices;
+
+import java.util.Map;
+
+import com.ctre.phoenix6.CANBus;
+
+/**
+ * Tagalong CANBus manager instance manager, only CTRE devices are currently registered or supported
+ */
+public class TagalongCANBus {
+  /**
+   * Map of all instances with a CTRE device registered to them
+   */
+  private static final Map<String, CANBus> _ctreCANBus = Map.of();
+
+  /**
+   * Gets or registers a CTRE CANBus instance with the given name
+   * 
+   * @param canBusName Name of the CANBus
+   * @return CTRE CANBus instance
+   */
+  public static CANBus getOrRegisterPhoenixCANBus(String canBusName) {
+    CANBus bus = _ctreCANBus.get(canBusName);
+    if (bus == null) {
+      bus = new CANBus(canBusName);
+      _ctreCANBus.put(canBusName, bus);
+    }
+    return bus;
+  }
+
+  /**
+   * Gets the map of all registered CTRE CANBus instances
+   * 
+   * @return Map of CANBus instances
+   */
+  public static Map<String, CANBus> getPhoenixCANBusMap() {
+    return _ctreCANBus;
+  }
+
+}

--- a/src/main/java/tagalong/logging/ElevatorIOInputsAutoLogged.java
+++ b/src/main/java/tagalong/logging/ElevatorIOInputsAutoLogged.java
@@ -13,7 +13,7 @@ public class ElevatorIOInputsAutoLogged
   @Override
   public void toLog(LogTable table) {
     table.put("ElevatorHeightM", elevatorHeightM, "meters");
-    table.put("ElevatorVelocityMPS", elevatorVelocityMPS, "meters/second");
+    table.put("ElevatorVelocityMPS", elevatorVelocityMPS, "mps");
     table.put("ElevatorAppliedVolts", elevatorAppliedVolts, "volts");
     table.put("ElevatorCurrentAmps", elevatorCurrentAmps, "amps");
   }

--- a/src/main/java/tagalong/logging/ElevatorIOInputsAutoLogged.java
+++ b/src/main/java/tagalong/logging/ElevatorIOInputsAutoLogged.java
@@ -12,10 +12,10 @@ public class ElevatorIOInputsAutoLogged
     extends ElevatorIO.ElevatorIOInputs implements LoggableInputs, Cloneable {
   @Override
   public void toLog(LogTable table) {
-    table.put("ElevatorHeightM", elevatorHeightM);
-    table.put("ElevatorVelocityMPS", elevatorVelocityMPS);
-    table.put("ElevatorAppliedVolts", elevatorAppliedVolts);
-    table.put("ElevatorCurrentAmps", elevatorCurrentAmps);
+    table.put("ElevatorHeightM", elevatorHeightM, "meters");
+    table.put("ElevatorVelocityMPS", elevatorVelocityMPS, "meters/second");
+    table.put("ElevatorAppliedVolts", elevatorAppliedVolts, "volts");
+    table.put("ElevatorCurrentAmps", elevatorCurrentAmps, "amps");
   }
 
   @Override

--- a/src/main/java/tagalong/logging/PivotIOInputsAutoLogged.java
+++ b/src/main/java/tagalong/logging/PivotIOInputsAutoLogged.java
@@ -13,7 +13,7 @@ public class PivotIOInputsAutoLogged
   @Override
   public void toLog(LogTable table) {
     table.put("PivotPositionRot", pivotPositionRot, "rotations");
-    table.put("PivotVelocityRPS", pivotVelocityRPS, "rotations/second");
+    table.put("PivotVelocityRPS", pivotVelocityRPS, "rps");
     table.put("PivotAppliedVolts", pivotAppliedVolts, "volts");
     table.put("PivotCurrentAmps", pivotCurrentAmps, "amps");
   }

--- a/src/main/java/tagalong/logging/PivotIOInputsAutoLogged.java
+++ b/src/main/java/tagalong/logging/PivotIOInputsAutoLogged.java
@@ -12,10 +12,10 @@ public class PivotIOInputsAutoLogged
     extends PivotIO.PivotIOInputs implements LoggableInputs, Cloneable {
   @Override
   public void toLog(LogTable table) {
-    table.put("PivotPositionRot", pivotPositionRot);
-    table.put("PivotVelocityRPS", pivotVelocityRPS);
-    table.put("PivotAppliedVolts", pivotAppliedVolts);
-    table.put("PivotCurrentAmps", pivotCurrentAmps);
+    table.put("PivotPositionRot", pivotPositionRot, "rotations");
+    table.put("PivotVelocityRPS", pivotVelocityRPS, "rotations/second");
+    table.put("PivotAppliedVolts", pivotAppliedVolts, "volts");
+    table.put("PivotCurrentAmps", pivotCurrentAmps, "amps");
   }
 
   @Override

--- a/src/main/java/tagalong/logging/RollerIOInputsAutoLogged.java
+++ b/src/main/java/tagalong/logging/RollerIOInputsAutoLogged.java
@@ -13,7 +13,7 @@ public class RollerIOInputsAutoLogged
   @Override
   public void toLog(LogTable table) {
     table.put("RollerPositionRot", rollerPositionRot, "rotations");
-    table.put("RollerVelocityRPS", rollerVelocityRPS, "rotations/second");
+    table.put("RollerVelocityRPS", rollerVelocityRPS, "rps");
     table.put("RollerAppliedVolts", rollerAppliedVolts, "volts");
     table.put("RollerCurrentAmps", rollerCurrentAmps, "amps");
   }

--- a/src/main/java/tagalong/logging/RollerIOInputsAutoLogged.java
+++ b/src/main/java/tagalong/logging/RollerIOInputsAutoLogged.java
@@ -12,10 +12,10 @@ public class RollerIOInputsAutoLogged
     extends RollerIO.RollerIOInputs implements LoggableInputs, Cloneable {
   @Override
   public void toLog(LogTable table) {
-    table.put("RollerPositionRot", rollerPositionRot);
-    table.put("RollerVelocityRPS", rollerVelocityRPS);
-    table.put("RollerAppliedVolts", rollerAppliedVolts);
-    table.put("RollerCurrentAmps", rollerCurrentAmps);
+    table.put("RollerPositionRot", rollerPositionRot, "rotations");
+    table.put("RollerVelocityRPS", rollerVelocityRPS, "rotations/second");
+    table.put("RollerAppliedVolts", rollerAppliedVolts, "volts");
+    table.put("RollerCurrentAmps", rollerCurrentAmps, "amps");
   }
 
   @Override

--- a/src/main/java/tagalong/math/AlgebraicUtils.java
+++ b/src/main/java/tagalong/math/AlgebraicUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/math/GeometricUtils.java
+++ b/src/main/java/tagalong/math/GeometricUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/math/LinearizedLookupTable.java
+++ b/src/main/java/tagalong/math/LinearizedLookupTable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/measurements/AlliancePose2d.java
+++ b/src/main/java/tagalong/measurements/AlliancePose2d.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/measurements/AlliancePose3d.java
+++ b/src/main/java/tagalong/measurements/AlliancePose3d.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/measurements/AllianceTranslation2d.java
+++ b/src/main/java/tagalong/measurements/AllianceTranslation2d.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/measurements/Angle.java
+++ b/src/main/java/tagalong/measurements/Angle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/measurements/Height.java
+++ b/src/main/java/tagalong/measurements/Height.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/subsystems/TagalongSubsystemBase.java
+++ b/src/main/java/tagalong/subsystems/TagalongSubsystemBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/subsystems/micro/Elevator.java
+++ b/src/main/java/tagalong/subsystems/micro/Elevator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/subsystems/micro/Microsystem.java
+++ b/src/main/java/tagalong/subsystems/micro/Microsystem.java
@@ -29,6 +29,7 @@ import edu.wpi.first.wpilibj.smartdashboard.Mechanism2d;
 import edu.wpi.first.wpilibj.smartdashboard.MechanismRoot2d;
 import tagalong.TagalongConfiguration;
 import tagalong.controls.PIDSGVAConstants;
+import tagalong.devices.TagalongCANBus;
 import tagalong.subsystems.micro.confs.MicrosystemConf;
 
 /**
@@ -187,7 +188,9 @@ public class Microsystem {
     // Initialize motors
     _allMotors = new TalonFX[conf.numMotors];
     for (int i = 0; i < conf.numMotors; i++) {
-      _allMotors[i] = new TalonFX(conf.motorDeviceIDs[i], conf.motorCanBus[i]);
+      _allMotors[i] = new TalonFX(
+          conf.motorDeviceIDs[i], TagalongCANBus.getOrRegisterPhoenixCANBus(conf.motorCanBus[i])
+      );
     }
     _primaryMotor = _allMotors[0];
     // FUTURE DEV: Inject this here rather than robot builder

--- a/src/main/java/tagalong/subsystems/micro/Microsystem.java
+++ b/src/main/java/tagalong/subsystems/micro/Microsystem.java
@@ -375,6 +375,19 @@ public class Microsystem {
   }
 
   /**
+   * exits method if micro system is disabled, if enabled sets primary motor to
+   * specified value
+   *
+   * @param powerV desired voltage
+   */
+  public void setPrimaryVolts(double powerV) {
+    if (_isMicrosystemDisabled) {
+      return;
+    }
+    _primaryMotor.setVoltage(powerV);
+  }
+
+  /**
    * @return double(0.0 if micro system is disabled or actual power of primary
    *         motor)
    */

--- a/src/main/java/tagalong/subsystems/micro/Microsystem.java
+++ b/src/main/java/tagalong/subsystems/micro/Microsystem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/subsystems/micro/Pivot.java
+++ b/src/main/java/tagalong/subsystems/micro/Pivot.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */
@@ -106,7 +106,9 @@ public class Pivot extends Microsystem {
    * Simulated arm of the pivot
    */
   protected MechanismLigament2d _pivotLigament;
-
+  /**
+   * Dynamic scope offset to handle absolute encoders and unpredictable boot locations
+   */
   protected double _scopeOffset = 0.0;
 
   /**
@@ -700,6 +702,11 @@ public class Pivot extends Microsystem {
     return _pivotLigament;
   }
 
+  /**
+   * Gets the configured scope offset for the pivot
+   *
+   * @return scope offset in rotations
+   */
   public double getScopeOffset() {
     return _scopeOffset;
   }

--- a/src/main/java/tagalong/subsystems/micro/Pivot.java
+++ b/src/main/java/tagalong/subsystems/micro/Pivot.java
@@ -331,7 +331,19 @@ public class Pivot extends Microsystem {
    * @return offset position in rotations
    */
   public double getFFPositionRad() {
-    return 0.0;
+    return _ffCenterOfMassOffsetRad;
+  }
+
+  /**
+   * Sets the position of the pivot in rotations
+   *
+   * @param rotations position set in rotations
+   */
+  public void setElevatorHeight(double rotations) {
+    if (_isMicrosystemDisabled) {
+      return;
+    }
+    _primaryMotor.setPosition(pivotRotToMotor(rotations));
   }
 
   /**

--- a/src/main/java/tagalong/subsystems/micro/Pivot.java
+++ b/src/main/java/tagalong/subsystems/micro/Pivot.java
@@ -331,7 +331,19 @@ public class Pivot extends Microsystem {
    * @return offset position in rotations
    */
   public double getFFPositionRad() {
-    return 0.0;
+    return _ffCenterOfMassOffsetRad;
+  }
+
+  /**
+   * Sets the position of the pivot in rotations
+   *
+   * @param rotations position set in rotations
+   */
+  public void setPivotPosition(double rotations) {
+    if (_isMicrosystemDisabled) {
+      return;
+    }
+    _primaryMotor.setPosition(pivotRotToMotor(rotations));
   }
 
   /**

--- a/src/main/java/tagalong/subsystems/micro/PivotFused.java
+++ b/src/main/java/tagalong/subsystems/micro/PivotFused.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */
@@ -30,6 +30,9 @@ public class PivotFused extends Pivot {
    * Configuration for the CANcoder
    */
   protected CANcoderConfiguration _pivotCancoderConfiguration;
+  /**
+   * Whether the fused cancoder has been setup yet
+   */
   protected boolean _fusedCancoderSetup = false;
   /**
    * Constructs a pivot microsystem with the below configurations
@@ -45,7 +48,7 @@ public class PivotFused extends Pivot {
   }
 
   private void setupFusedCancoder() {
-    if(!_fusedCancoderSetup) {
+    if (!_fusedCancoderSetup) {
       _pivotCancoder = new CANcoder(_pivotConf.encoderDeviceID, _pivotConf.encoderCanBus);
       _pivotCancoderConfiguration = _pivotConf.encoderConfig;
       configCancoder();

--- a/src/main/java/tagalong/subsystems/micro/PivotFused.java
+++ b/src/main/java/tagalong/subsystems/micro/PivotFused.java
@@ -16,6 +16,7 @@ import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj.simulation.BatterySim;
 import edu.wpi.first.wpilibj.simulation.RoboRioSim;
 import tagalong.TagalongConfiguration;
+import tagalong.devices.TagalongCANBus;
 import tagalong.subsystems.micro.confs.PivotConf;
 
 /**
@@ -49,7 +50,10 @@ public class PivotFused extends Pivot {
 
   private void setupFusedCancoder() {
     if (!_fusedCancoderSetup) {
-      _pivotCancoder = new CANcoder(_pivotConf.encoderDeviceID, _pivotConf.encoderCanBus);
+      _pivotCancoder = new CANcoder(
+          _pivotConf.encoderDeviceID,
+          TagalongCANBus.getOrRegisterPhoenixCANBus(_pivotConf.encoderCanBus)
+      );
       _pivotCancoderConfiguration = _pivotConf.encoderConfig;
       configCancoder();
       configAllDevices();

--- a/src/main/java/tagalong/subsystems/micro/PivotNoCancoder.java
+++ b/src/main/java/tagalong/subsystems/micro/PivotNoCancoder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/subsystems/micro/PivotUnfused.java
+++ b/src/main/java/tagalong/subsystems/micro/PivotUnfused.java
@@ -21,6 +21,7 @@ import edu.wpi.first.wpilibj.smartdashboard.MechanismLigament2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj.util.Color8Bit;
 import tagalong.TagalongConfiguration;
+import tagalong.devices.TagalongCANBus;
 import tagalong.subsystems.micro.confs.PivotConf;
 
 /**
@@ -45,7 +46,10 @@ public class PivotUnfused extends Pivot {
     if (_configuredMicrosystemDisable) {
       return;
     }
-    _pivotCancoder = new CANcoder(_pivotConf.encoderDeviceID, _pivotConf.encoderCanBus);
+    _pivotCancoder = new CANcoder(
+        _pivotConf.encoderDeviceID,
+        TagalongCANBus.getOrRegisterPhoenixCANBus(_pivotConf.encoderCanBus)
+    );
     _pivotCancoderConfiguration = _pivotConf.encoderConfig;
     configCancoder();
     configAllDevices();

--- a/src/main/java/tagalong/subsystems/micro/PivotUnfused.java
+++ b/src/main/java/tagalong/subsystems/micro/PivotUnfused.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/subsystems/micro/Roller.java
+++ b/src/main/java/tagalong/subsystems/micro/Roller.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/subsystems/micro/augments/ElevatorAugment.java
+++ b/src/main/java/tagalong/subsystems/micro/augments/ElevatorAugment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/subsystems/micro/augments/PivotAugment.java
+++ b/src/main/java/tagalong/subsystems/micro/augments/PivotAugment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/subsystems/micro/augments/RollerAugment.java
+++ b/src/main/java/tagalong/subsystems/micro/augments/RollerAugment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/subsystems/micro/confs/ElevatorConf.java
+++ b/src/main/java/tagalong/subsystems/micro/confs/ElevatorConf.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/subsystems/micro/confs/MicrosystemConf.java
+++ b/src/main/java/tagalong/subsystems/micro/confs/MicrosystemConf.java
@@ -6,7 +6,6 @@
 
 package tagalong.subsystems.micro.confs;
 
-import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.signals.InvertedValue;
@@ -15,7 +14,6 @@ import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj.IterativeRobotBase;
 import tagalong.controls.PIDSGVAConstants;
 import tagalong.devices.Motors;
-import tagalong.devices.TagalongCANBus;
 import tagalong.units.AccelerationUnits;
 import tagalong.units.DistanceUnits;
 import tagalong.units.VelocityUnits;
@@ -54,7 +52,7 @@ public class MicrosystemConf {
   /**
    * The can bus of the motors
    */
-  public final CANBus[] motorCanBus;
+  public final String[] motorCanBus;
   /**
    * The motor directionality
    */
@@ -169,6 +167,7 @@ public class MicrosystemConf {
 
     this.motorTypes = motorTypes;
     this.motorDeviceIDs = motorDeviceIDs;
+    this.motorCanBus = motorCanBus;
     this.motorDirection = motorDirection;
     this.motorEnabledBrakeMode = motorEnabledBrakeMode;
     this.motorDisabledBrakeMode = motorDisabledBrakeMode;
@@ -183,10 +182,8 @@ public class MicrosystemConf {
     this.motorToMechRatio = calculateGearRatio(gearRatio);
     assert (this.motorToMechRatio > 0.0);
 
-    this.motorCanBus = new CANBus[numMotors];
     motorConfig = new TalonFXConfiguration[numMotors];
     for (int i = 0; i < numMotors; i++) {
-      this.motorCanBus[i] = TagalongCANBus.getOrRegisterPhoenixCANBus(motorCanBus[i]);
       motorConfig[i] = Motors.getDefaults();
       motorConfig[i].MotorOutput.Inverted = motorDirection[i];
       motorConfig[i].MotorOutput.NeutralMode = motorDisabledBrakeMode[i];

--- a/src/main/java/tagalong/subsystems/micro/confs/MicrosystemConf.java
+++ b/src/main/java/tagalong/subsystems/micro/confs/MicrosystemConf.java
@@ -1,11 +1,12 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */
 
 package tagalong.subsystems.micro.confs;
 
+import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.signals.InvertedValue;
@@ -14,6 +15,7 @@ import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.wpilibj.IterativeRobotBase;
 import tagalong.controls.PIDSGVAConstants;
 import tagalong.devices.Motors;
+import tagalong.devices.TagalongCANBus;
 import tagalong.units.AccelerationUnits;
 import tagalong.units.DistanceUnits;
 import tagalong.units.VelocityUnits;
@@ -52,7 +54,7 @@ public class MicrosystemConf {
   /**
    * The can bus of the motors
    */
-  public final String[] motorCanBus;
+  public final CANBus[] motorCanBus;
   /**
    * The motor directionality
    */
@@ -167,7 +169,6 @@ public class MicrosystemConf {
 
     this.motorTypes = motorTypes;
     this.motorDeviceIDs = motorDeviceIDs;
-    this.motorCanBus = motorCanBus;
     this.motorDirection = motorDirection;
     this.motorEnabledBrakeMode = motorEnabledBrakeMode;
     this.motorDisabledBrakeMode = motorDisabledBrakeMode;
@@ -182,8 +183,10 @@ public class MicrosystemConf {
     this.motorToMechRatio = calculateGearRatio(gearRatio);
     assert (this.motorToMechRatio > 0.0);
 
+    this.motorCanBus = new CANBus[numMotors];
     motorConfig = new TalonFXConfiguration[numMotors];
     for (int i = 0; i < numMotors; i++) {
+      this.motorCanBus[i] = TagalongCANBus.getOrRegisterPhoenixCANBus(motorCanBus[i]);
       motorConfig[i] = Motors.getDefaults();
       motorConfig[i].MotorOutput.Inverted = motorDirection[i];
       motorConfig[i].MotorOutput.NeutralMode = motorDisabledBrakeMode[i];

--- a/src/main/java/tagalong/subsystems/micro/confs/PivotConf.java
+++ b/src/main/java/tagalong/subsystems/micro/confs/PivotConf.java
@@ -6,7 +6,6 @@
 
 package tagalong.subsystems.micro.confs;
 
-import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.MagnetSensorConfigs;
@@ -19,7 +18,6 @@ import tagalong.controls.FeedforwardConstants;
 import tagalong.controls.PIDSGVAConstants;
 import tagalong.devices.Encoders;
 import tagalong.devices.Motors;
-import tagalong.devices.TagalongCANBus;
 import tagalong.units.AccelerationUnits;
 import tagalong.units.DistanceUnits;
 import tagalong.units.VelocityUnits;
@@ -52,7 +50,7 @@ public class PivotConf extends MicrosystemConf {
   /**
    * CAN bus of the encoder
    */
-  public final CANBus encoderCanBus;
+  public final String encoderCanBus;
   /**
    * Ratio between the motor and encoder
    */
@@ -276,7 +274,7 @@ public class PivotConf extends MicrosystemConf {
     );
     this.encoderType = encoderType;
     this.encoderDeviceID = encoderDeviceID;
-    this.encoderCanBus = TagalongCANBus.getOrRegisterPhoenixCANBus(encoderCanBus);
+    this.encoderCanBus = encoderCanBus;
     this.encoderToPivotRatio = super.calculateGearRatio(encoderToPivotRatio);
     this.motorToEncoderRatio =
         super.calculateGearRatio(motorToPivotRatio) / this.encoderToPivotRatio;

--- a/src/main/java/tagalong/subsystems/micro/confs/PivotConf.java
+++ b/src/main/java/tagalong/subsystems/micro/confs/PivotConf.java
@@ -1,11 +1,12 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */
 
 package tagalong.subsystems.micro.confs;
 
+import com.ctre.phoenix6.CANBus;
 import com.ctre.phoenix6.configs.CANcoderConfiguration;
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.MagnetSensorConfigs;
@@ -18,6 +19,7 @@ import tagalong.controls.FeedforwardConstants;
 import tagalong.controls.PIDSGVAConstants;
 import tagalong.devices.Encoders;
 import tagalong.devices.Motors;
+import tagalong.devices.TagalongCANBus;
 import tagalong.units.AccelerationUnits;
 import tagalong.units.DistanceUnits;
 import tagalong.units.VelocityUnits;
@@ -50,7 +52,7 @@ public class PivotConf extends MicrosystemConf {
   /**
    * CAN bus of the encoder
    */
-  public final String encoderCanBus;
+  public final CANBus encoderCanBus;
   /**
    * Ratio between the motor and encoder
    */
@@ -274,7 +276,7 @@ public class PivotConf extends MicrosystemConf {
     );
     this.encoderType = encoderType;
     this.encoderDeviceID = encoderDeviceID;
-    this.encoderCanBus = encoderCanBus;
+    this.encoderCanBus = TagalongCANBus.getOrRegisterPhoenixCANBus(encoderCanBus);
     this.encoderToPivotRatio = super.calculateGearRatio(encoderToPivotRatio);
     this.motorToEncoderRatio =
         super.calculateGearRatio(motorToPivotRatio) / this.encoderToPivotRatio;

--- a/src/main/java/tagalong/subsystems/micro/confs/RollerConf.java
+++ b/src/main/java/tagalong/subsystems/micro/confs/RollerConf.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/units/AccelerationUnits.java
+++ b/src/main/java/tagalong/units/AccelerationUnits.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/units/DistanceUnits.java
+++ b/src/main/java/tagalong/units/DistanceUnits.java
@@ -1,11 +1,11 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */
 
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/units/MassUnits.java
+++ b/src/main/java/tagalong/units/MassUnits.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/units/TimeUnits.java
+++ b/src/main/java/tagalong/units/TimeUnits.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/main/java/tagalong/units/VelocityUnits.java
+++ b/src/main/java/tagalong/units/VelocityUnits.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/test/java/tagalong/math/AlgebraicUtilsTest.java
+++ b/src/test/java/tagalong/math/AlgebraicUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/test/java/tagalong/math/GeometricUtilsTest.java
+++ b/src/test/java/tagalong/math/GeometricUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/test/java/tagalong/units/AccelerationUnitsTest.java
+++ b/src/test/java/tagalong/units/AccelerationUnitsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/test/java/tagalong/units/DistanceUnitsTest.java
+++ b/src/test/java/tagalong/units/DistanceUnitsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/test/java/tagalong/units/MassUnitsTest.java
+++ b/src/test/java/tagalong/units/MassUnitsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/test/java/tagalong/units/TimeUnitsTest.java
+++ b/src/test/java/tagalong/units/TimeUnitsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */

--- a/src/test/java/tagalong/units/VelocityUnitsTest.java
+++ b/src/test/java/tagalong/units/VelocityUnitsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
+ * Copyright 2024-2026 The Space Cookies : Girl Scout Troop #62868 and FRC Team #1868
  * Open Source Software; you may modify and/or share it under the terms of
  * the 3-Clause BSD License found in the root directory of this project.
  */


### PR DESCRIPTION
Probably should have split this up into a copyright PR and other PR, oops

Bump copyright year, adapt to some 2026 library changes (namely CANBus conventions in phoenix 6), fix some leftover 2025 formatting and TODOs

TODO: add advantage scope CANBus logging